### PR TITLE
다음 티어 정보와 현재까지의 포인트 추가

### DIFF
--- a/src/main/java/hyundai/movie_review/member/dto/GetMemberMyPageResponse.java
+++ b/src/main/java/hyundai/movie_review/member/dto/GetMemberMyPageResponse.java
@@ -31,14 +31,14 @@ public record GetMemberMyPageResponse(
    @Schema(description = "멤버가 작성한 리뷰 정보")
    ReviewInfoListDto reviewInfoList
 ) {
-   public static GetMemberMyPageResponse of(Member member, GenreCountListDto genreList,
+   public static GetMemberMyPageResponse of(Member member, String nextTierName, GenreCountListDto genreList,
                                             ReviewCountArrayDto starRateList, ReviewInfoListDto reviewInfoList){
 
       return new GetMemberMyPageResponse(
               member.getName(),
               member.getProfileImage(),
               BadgeMyPageInfoDto.of(member),
-              TierMyPageInfoDto.of(member.getTier(), member.getTotalScore()),
+              TierMyPageInfoDto.of(member.getTier(), member.getTotalScore(), nextTierName),
               genreList,
               starRateList,
               reviewInfoList

--- a/src/main/java/hyundai/movie_review/member/service/MemberService.java
+++ b/src/main/java/hyundai/movie_review/member/service/MemberService.java
@@ -28,6 +28,8 @@ import hyundai.movie_review.security.MemberResolver;
 import hyundai.movie_review.thear_down.repository.ThearDownRepository;
 import hyundai.movie_review.thear_up.repository.ThearUpRepository;
 import java.io.IOException;
+
+import hyundai.movie_review.tier.repository.TierRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,6 +54,7 @@ public class MemberService {
 
     private final MemberResolver memberResolver;
     private final BadgeRepository badgeRepository;
+    private final TierRepository tierRepository;
     private final GenreRepository genreRepository;
     private final ReviewRepository reviewRepository;
     private final ThearUpRepository thearUpRepository;
@@ -74,6 +77,14 @@ public class MemberService {
                     .orElseThrow(MemberIdNotFoundException::new);
         }
         else{ member = memberResolver.getCurrentMember(); }
+        String nextTier = "영화의 신";
+        Long tierTotal = tierRepository.count();
+        Long tierNow = member.getTier().getId();
+        if(tierNow < tierTotal) {
+            nextTier = tierRepository.findById(tierNow+1)
+                    .orElseThrow(BadgeIdNotFoundException::new)
+                    .getName();
+        }
 
         // 2) 유저가 작성한 리뷰의 영화 장르들 가져오기
         GenreCountListDto genreCountList = genreRepository.getGenreCountByMember(member);
@@ -144,7 +155,7 @@ public class MemberService {
             }).toList();
         }
 
-        return GetMemberMyPageResponse.of(member, genreCountList, starRateList,
+        return GetMemberMyPageResponse.of(member, nextTier, genreCountList, starRateList,
                 ReviewInfoListDto.of(reviewDtoList));
     }
 

--- a/src/main/java/hyundai/movie_review/tier/dto/TierMyPageInfoDto.java
+++ b/src/main/java/hyundai/movie_review/tier/dto/TierMyPageInfoDto.java
@@ -5,17 +5,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "마이페이지에 필요한 티어 정보 DTO")
 public record TierMyPageInfoDto (
-        @Schema(description = "티어 ID", example = "1")
+        @Schema(description = "티어 ID", example = "2")
         Long tierId,
-        @Schema(description = "티어 이름", example = "띠어력 신입")
+        @Schema(description = "티어 이름", example = "띠어력 초보")
         String tierName,
-        @Schema(description = "다음 티어 이름", example = "띠어력 초보")
+        @Schema(description = "다음 티어 이름", example = "띠어력 중수")
         String nextTierName,
         @Schema(description = "티어 이미지 경로", example = "http://k.kakaocdn.net/...")
         String tierImage,
+        @Schema(description = "사용자의 총 점수", example = "130")
+        Long tierTotalPoints,
         @Schema(description = "현재 티어에서 다음 티어까지 필요한 총 점수", example = "100")
         Long tierRequiredPoints,
-        @Schema(description = "사용자의 점수", example = "30")
+        @Schema(description = "현재 티어에서 쌓은 점수", example = "30")
         Long tierCurrentPoints
 ){
     public static TierMyPageInfoDto of(Tier tier, Long score, String nextTierName){
@@ -43,6 +45,7 @@ public record TierMyPageInfoDto (
                 tier.getName(),
                 nextTierName,
                 tier.getImage(),
+                score,
                 requiredPoints,
                 currentPoints
         );

--- a/src/main/java/hyundai/movie_review/tier/dto/TierMyPageInfoDto.java
+++ b/src/main/java/hyundai/movie_review/tier/dto/TierMyPageInfoDto.java
@@ -9,6 +9,8 @@ public record TierMyPageInfoDto (
         Long tierId,
         @Schema(description = "티어 이름", example = "띠어력 신입")
         String tierName,
+        @Schema(description = "다음 티어 이름", example = "띠어력 초보")
+        String nextTierName,
         @Schema(description = "티어 이미지 경로", example = "http://k.kakaocdn.net/...")
         String tierImage,
         @Schema(description = "현재 티어에서 다음 티어까지 필요한 총 점수", example = "100")
@@ -16,7 +18,7 @@ public record TierMyPageInfoDto (
         @Schema(description = "사용자의 점수", example = "30")
         Long tierCurrentPoints
 ){
-    public static TierMyPageInfoDto of(Tier tier, Long score){
+    public static TierMyPageInfoDto of(Tier tier, Long score, String nextTierName){
         long requiredPoints = 0, currentPoints = 0;
 
         // Lv 1 ~ 3은 다음 티어/레벨까지 100 포인트 필요
@@ -39,6 +41,7 @@ public record TierMyPageInfoDto (
         return new TierMyPageInfoDto(
                 tier.getId(),
                 tier.getName(),
+                nextTierName,
                 tier.getImage(),
                 requiredPoints,
                 currentPoints


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #133

## 📝작업 내용

마이페이지에서 사용자의 다음 티어 이름과 현재까지 쌓은 전체 포인트를 추가로 조회할 수 있습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
